### PR TITLE
Return video stream index stored in _videoIdx

### DIFF
--- a/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegReader.hpp
+++ b/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegReader.hpp
@@ -32,7 +32,7 @@ private:
 
 	AVStream* getVideoStream()
 	{
-		return _context && _currVideoIdx >= 0 ? _context->streams[_currVideoIdx] : NULL;
+		return _context && _currVideoIdx >= 0 ? _context->streams[_videoIdx[_currVideoIdx]] : NULL;
 	}
 
 	void    openVideoCodec();


### PR DESCRIPTION
_currVideoIdx is 0 whenever a video stream is found. It is not the index of
the video stream, rather an index in _videoIdx which stores the indexes of
the video stream.
