### PR TITLE
Replace some deprecated FFmpeg functions with current ones

### DIFF
--- a/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegReader.cpp
+++ b/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegReader.cpp
@@ -75,7 +75,7 @@ bool VideoFFmpegReader::open( const std::string& filename )
 		return false;
 	}
 	// FIXME_GC: needs to know if it's streamable.
-	error = av_find_stream_info( _context );
+	error = avformat_find_stream_info( _context, NULL );
 	if( error < 0 )
 	{
 		std::cerr << "ffmpegReader: " << ffmpegError_toString( error ) << std::endl;
@@ -138,7 +138,7 @@ void VideoFFmpegReader::close()
 	closeVideoCodec();
 	if( _context )
 	{
-		av_close_input_file( _context );
+		avformat_close_input( &_context );
 		_context = NULL;
 	}
 }
@@ -297,7 +297,7 @@ void VideoFFmpegReader::openVideoCodec()
 	{
 		AVCodecContext* codecContext = stream->codec;
 		_videoCodec = avcodec_find_decoder( codecContext->codec_id );
-		if( _videoCodec == NULL || avcodec_open( codecContext, _videoCodec ) < 0 )
+		if( _videoCodec == NULL || avcodec_open2( codecContext, _videoCodec, NULL ) < 0 )
 		{
 			_currVideoIdx = -1;
 		}

--- a/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegWriter.cpp
+++ b/plugins/image/io/FFMpeg/src/ffmpeg/VideoFFmpegWriter.cpp
@@ -101,17 +101,17 @@ int VideoFFmpegWriter::execute( boost::uint8_t* in_buffer, int in_width, int in_
 
 	if( !_stream )
 	{
-		_stream = av_new_stream( _avformatOptions, 0 );
+		CodecID codecId    = fmt->video_codec;
+		AVCodec* userCodec = avcodec_find_encoder_by_name( _codec.c_str() );
+		if( userCodec )
+			codecId = userCodec->id;
+
+		_stream = avformat_new_stream( _avformatOptions, userCodec );
 		if( !_stream )
 		{
 			std::cout << "ffmpegWriter: out of memory." << std::endl;
 			return false;
 		}
-
-		CodecID codecId    = fmt->video_codec;
-		AVCodec* userCodec = avcodec_find_encoder_by_name( _codec.c_str() );
-		if( userCodec )
-			codecId = userCodec->id;
 
 		_stream->codec->codec_id           = codecId;
 		_stream->codec->codec_type         = AVMEDIA_TYPE_VIDEO;
@@ -154,7 +154,7 @@ int VideoFFmpegWriter::execute( boost::uint8_t* in_buffer, int in_width, int in_
 			return false;
 		}
 
-		if( avcodec_open( _stream->codec, videoCodec ) < 0 )
+		if( avcodec_open2( _stream->codec, videoCodec, NULL ) < 0 )
 		{
 			std::cout << "ffmpegWriter: unable to open codec." << std::endl;
 			freeFormat();


### PR DESCRIPTION
This changes the following functions:
- av_new_stream       -> avformat_new_stream
- avcodec_open        -> avcodec_open2
- av_find_stream_info -> avformat_find_stream_info
- av_close_input_file -> avformat_close_input
