### PR TITLE
tuttleHost: getProjectSize and getProjectExtent return RoD

### DIFF
--- a/libraries/tuttle/src/tuttle/host/INode.cpp
+++ b/libraries/tuttle/src/tuttle/host/INode.cpp
@@ -94,6 +94,24 @@ INode::DataAtTime& INode::getData( const OfxTime time )
 	return const_cast<DataAtTime&>( const_cast<const This*>(this)->getData(time) );
 }
 
+const INode::DataAtTime& INode::getFirstData() const
+{
+	DataAtTimeMap::const_iterator it = _dataAtTime.begin();
+	if( it == _dataAtTime.end() )
+	{
+		BOOST_THROW_EXCEPTION( exception::Bug()
+			<< exception::dev() + "Process data empty.\n"
+				       << exception::nodeName( getName() ) );
+	}
+	
+	return *it->second;
+}
+
+INode::DataAtTime& INode::getFirstData()
+{
+	return const_cast<DataAtTime&>( const_cast<const This*>(this)->getFirstData() );
+}
+
 std::ostream& operator<<( std::ostream& os, const INode& v )
 {
 	return v.print(os);

--- a/libraries/tuttle/src/tuttle/host/INode.hpp
+++ b/libraries/tuttle/src/tuttle/host/INode.hpp
@@ -205,7 +205,9 @@ public:
 	Data& getData();
 	const Data& getData() const;
 	const DataAtTime& getData( const OfxTime time ) const;
+	const DataAtTime& getFirstData() const; 
 	DataAtTime& getData( const OfxTime time );
+	DataAtTime& getFirstData();
 
 	#endif
 };

--- a/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
@@ -130,7 +130,7 @@ void ImageEffectNode::vmessage( const char* type,
 // get the project size in CANONICAL pixels, so PAL SD return 768, 576
 void ImageEffectNode::getProjectSize( double& xSize, double& ySize ) const
 {
-	OfxRectD rod = getData(0.0f)._apiImageEffect._renderRoD;
+	OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
 	xSize = rod.x2 - rod.x1;
 	ySize = rod.y2 - rod.y1;
 	if (xSize < 1 || ySize < 1)
@@ -150,7 +150,7 @@ void ImageEffectNode::getProjectOffset( double& xOffset, double& yOffset ) const
 // get the project extent in CANONICAL pixels, so PAL SD return 768, 576
 void ImageEffectNode::getProjectExtent( double& xSize, double& ySize ) const
 {
-	OfxRectD rod = getData(0.0f)._apiImageEffect._renderRoD;
+	OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
 	xSize = rod.x2 - rod.x1;
 	ySize = rod.y2 - rod.y1;
 	if (xSize < 1 || ySize < 1)


### PR DESCRIPTION
Returning RoD is more useful than just returning a hardcoded PAL resolution.
It isn't a complete solution, but it will ensure plugins written to use these values work more consistantly.
