### PR TITLE
MemoryBuffer Plugin: Implemented Output Buffer

### DIFF
--- a/libraries/tuttle/src/tuttle/host/Graph.cpp
+++ b/libraries/tuttle/src/tuttle/host/Graph.cpp
@@ -29,6 +29,14 @@ InputBufferWrapper Graph::createInputBuffer()
 	return nodeWrapper;
 }
 
+OutputBufferWrapper Graph::createOutputBuffer()
+{
+	Node& node = createNode( "tuttle.outputbuffer" );
+	OutputBufferWrapper nodeWrapper( node );
+	
+	return nodeWrapper;
+}
+
 Graph::Node& Graph::createNode( const std::string& id )
 {
 	ofx::imageEffect::OfxhImageEffectPlugin* plug = Core::instance().getImageEffectPluginById( id );

--- a/libraries/tuttle/src/tuttle/host/Graph.hpp
+++ b/libraries/tuttle/src/tuttle/host/Graph.hpp
@@ -6,6 +6,7 @@
 #include "Core.hpp"
 #include "INode.hpp"
 #include "InputBufferWrapper.hpp"
+#include "OutputBufferWrapper.hpp"
 #include "exceptions.hpp"
 
 #include <tuttle/host/graph/InternalGraph.hpp>
@@ -57,6 +58,12 @@ public:
 	 *        to give an input buffer.
 	 */
 	InputBufferWrapper createInputBuffer();
+
+	/**
+	 * @brief Create a new output buffer node in the current graph,
+	          wrapped up for easy use
+	 */
+	OutputBufferWrapper createOutputBuffer();
 
 	/**
 	 * @brief Create a new node in the current graph.

--- a/libraries/tuttle/src/tuttle/host/Graph.i
+++ b/libraries/tuttle/src/tuttle/host/Graph.i
@@ -1,6 +1,7 @@
 %include <tuttle/host/global.i>
 %include <tuttle/host/memory/MemoryCache.i>
 %include <tuttle/host/InputBufferWrapper.i>
+%include <tuttle/host/OutputBufferWrapper.i>
 %include <tuttle/host/ComputeOptions.i>
 %include <tuttle/host/NodeListArg.i>
 %include <tuttle/host/INode.i>

--- a/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.cpp
+++ b/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.cpp
@@ -1,0 +1,19 @@
+#include "OutputBufferWrapper.hpp"
+#include "Core.hpp"
+#include <tuttle/host/ofx/attribute/OfxhClipImageDescriptor.hpp>
+
+namespace tuttle {
+namespace host {
+
+void OutputBufferWrapper::setCallback( OutCallbackPtr callback, CallbackCustomDataPtr customData )
+{
+	_node.getParam( "callbackPointer" ).setValue(
+			boost::lexical_cast<std::string>( reinterpret_cast<std::ptrdiff_t>( callback ) )
+		);
+	_node.getParam( "callbackCustomData" ).setValue(
+			boost::lexical_cast<std::string>( reinterpret_cast<std::ptrdiff_t>( customData ) )
+		);
+}
+
+}
+}

--- a/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.hpp
+++ b/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.hpp
@@ -1,0 +1,66 @@
+#ifndef _TUTTLE_HOST_OUTPUTBUFFERWRAPPER_HPP_
+#define	_TUTTLE_HOST_OUTPUTBUFFERWRAPPER_HPP_
+
+#include "INode.hpp"
+#include <tuttle/host/attribute/Param.hpp>
+#include <tuttle/host/attribute/ClipImage.hpp>
+#include <tuttle/host/attribute/ClipImage.hpp>
+#include <tuttle/host/ofx/attribute/OfxhClipImageDescriptor.hpp>
+#include <tuttle/host/graph/ProcessVertexData.hpp>
+#include <tuttle/host/graph/ProcessVertexAtTimeData.hpp>
+
+namespace tuttle {
+namespace host {
+
+class OutputBufferWrapper
+{
+private:
+	INode& _node;
+	
+public:
+
+  enum EBitDepth
+    {
+      eBitDepthCustom = -1, ///< some non standard bit depth
+      eBitDepthNone = 0, ///< bit depth that indicates no data is present
+      eBitDepthUByte = 1,
+      eBitDepthUShort = 2,
+      eBitDepthFloat = 3
+    };
+
+
+  enum EPixelComponent
+    {
+      ePixelComponentNone,
+      ePixelComponentRGBA,
+      ePixelComponentRGB,
+      ePixelComponentAlpha,
+      ePixelComponentCustom ///< some non standard pixel type
+    };
+
+  enum EField
+    {
+      eFieldNone,   /**< @brief unfielded image */
+      eFieldBoth,   /**< @brief fielded image with both fields present */
+      eFieldLower,  /**< @brief only the spatially lower field is present */
+      eFieldUpper   /**< @brief only the spatially upper field is present  */
+    };
+
+       typedef void (*OutCallbackPtr)(OfxTime time, void* outputCustomData, void* rawdata, int width, int height, int rowSizeBytes, EBitDepth bitDepth, EPixelComponent components, EField field);
+       typedef void* CallbackCustomDataPtr;
+
+	OutputBufferWrapper( INode& node )
+	: _node(node)
+	{}
+	~OutputBufferWrapper(){}
+
+	INode& getNode() { return _node; }
+	
+	void setCallback( OutCallbackPtr callback, CallbackCustomDataPtr customData = NULL );
+};
+
+}
+}
+
+#endif
+

--- a/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.i
+++ b/libraries/tuttle/src/tuttle/host/OutputBufferWrapper.i
@@ -1,0 +1,35 @@
+%include <tuttle/host/global.i>
+%include <tuttle/host/INode.i>
+%include <tuttle/host/ofx/OfxhException.i>
+
+
+%{
+#define SWIG_FILE_WITH_INIT
+#include <tuttle/host/OutputBufferWrapper.hpp>
+%}
+
+%include "wrappers/numpy.i"
+
+%init %{
+import_array();
+%}
+
+%apply (unsigned char* INPLACE_ARRAY2, int DIM1, int DIM2) {(unsigned char* rawBuffer, int height, int width)};
+%apply (unsigned short* INPLACE_ARRAY2, int DIM1, int DIM2) {(unsigned short* rawBuffer, int height, int width)};
+%apply (float* INPLACE_ARRAY2, int DIM1, int DIM2) {(float* rawBuffer, int height, int width)};
+
+%apply (unsigned char* INPLACE_ARRAY3, int DIM1, int DIM2, int DIM3) {(unsigned char* rawBuffer, int height, int width, int nbComponents)};
+%apply (unsigned short* INPLACE_ARRAY3, int DIM1, int DIM2, int DIM3) {(unsigned short* rawBuffer, int height, int width, int nbComponents)};
+%apply (float* INPLACE_ARRAY3, int DIM1, int DIM2, int DIM3) {(float* rawBuffer, int height, int width, int nbComponents)};
+
+
+%include <tuttle/host/OutputBufferWrapper.hpp>
+
+%clear (float* rawBuffer, int width, int height);
+%clear (unsigned short* rawBuffer, int width, int height);
+%clear (unsigned char* rawBuffer, int width, int height);
+
+%clear (float* rawBuffer, int height, int width, int nbComponents);
+%clear (unsigned short* rawBuffer, int height, int width, int nbComponents);
+%clear (unsigned char* rawBuffer, int height, int width, int nbComponents);
+	

--- a/plugins/image/io/MemoryBuffer/src/mainEntry.cpp
+++ b/plugins/image/io/MemoryBuffer/src/mainEntry.cpp
@@ -2,6 +2,7 @@
 #define OFXPLUGIN_VERSION_MINOR 0
 
 #include "inputBuffer/InputBufferPluginFactory.hpp"
+#include "outputBuffer/OutputBufferPluginFactory.hpp"
 #include <tuttle/plugin/Plugin.hpp>
 
 namespace OFX {
@@ -10,6 +11,7 @@ namespace Plugin {
 void getPluginIDs( OFX::PluginFactoryArray& ids )
 {
 	mAppendPluginFactory( ids, tuttle::plugin::inputBuffer::InputBufferPluginFactory, "tuttle.inputbuffer" );
+	mAppendPluginFactory( ids, tuttle::plugin::outputBuffer::OutputBufferPluginFactory, "tuttle.outputbuffer" );
 }
 
 }

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferDefinitions.hpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferDefinitions.hpp
@@ -1,0 +1,18 @@
+#ifndef _TUTTLE_PLUGIN_OUTPUTBUFFER_DEFINITIONS_HPP_
+#define _TUTTLE_PLUGIN_OUTPUTBUFFER_DEFINITIONS_HPP_
+
+#include <tuttle/plugin/global.hpp>
+
+
+namespace tuttle {
+namespace plugin {
+namespace outputBuffer {
+
+static const std::string kParamOutputCallbackPointer = "callbackPointer";
+static const std::string kParamOutputCallbackCustomData = "callbackCustomData";
+
+}
+}
+}
+
+#endif

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.cpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.cpp
@@ -1,0 +1,133 @@
+#include "OutputBufferPlugin.hpp"
+#include "OutputBufferDefinitions.hpp"
+
+#include <tuttle/common/ofx/imageEffect.hpp>
+#include <tuttle/host/ofx/OfxhImage.hpp>
+
+#include <boost/assert.hpp>
+#include <boost/scoped_ptr.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/cstdint.hpp>
+
+namespace tuttle {
+namespace plugin {
+namespace outputBuffer {
+
+  /* @fixme duplicated in inputbuffer */
+void* stringToPointer( const std::string& value )
+{
+	if( value.empty() )
+		return NULL;
+	std::ptrdiff_t p = boost::lexical_cast<std::ptrdiff_t>( value );
+	return reinterpret_cast<void*>( p );
+}
+
+OutputBufferPlugin::OutputBufferPlugin( OfxImageEffectHandle handle )
+: OFX::ImageEffect( handle )
+{
+	_clipSrc = fetchClip( kOfxImageEffectSimpleSourceClipName );
+	_clipDst = fetchClip( kOfxImageEffectOutputClipName );
+
+	_paramOutputCallbackPointer = fetchStringParam( kParamOutputCallbackPointer );
+	_paramOutputCallbackCustomData = fetchStringParam( kParamOutputCallbackCustomData );
+}
+
+OutputBufferProcessParams OutputBufferPlugin::getProcessParams( const OfxTime time ) const
+{
+	OutputBufferProcessParams params;
+	params._callbackPtr = reinterpret_cast<OutCallbackPtr>( stringToPointer( _paramOutputCallbackPointer->getValue() ) );
+	params._callbackCustomDataPtr = static_cast<CallbackCustomDataPtr>( stringToPointer( _paramOutputCallbackCustomData->getValue() ) );
+	return params;
+}
+
+void OutputBufferPlugin::render( const OFX::RenderArguments& args )
+{
+	TUTTLE_TCOUT( "        --> Output Buffer ");
+	char* rawImage;
+	void* dataSrcPtr;
+	void* dataDstPtr;
+
+	std::size_t imageDataBytes;
+	std::size_t pixelSize = 0;
+
+	boost::scoped_ptr<OFX::Image> src( _clipSrc->fetchImage( args.time ) );
+	boost::scoped_ptr<OFX::Image> dst( _clipDst->fetchImage( args.time ) );
+
+	// Get Image info
+	const OfxRectI bounds = dst->getBounds();
+	const OFX::EBitDepth depth = dst->getPixelDepth();
+	const OFX::EPixelComponent components = dst->getPixelComponents();
+	const OFX::EField field = dst->getField();
+
+	// Find pixel size in bytes based on image info
+	switch (depth) {
+	case OFX::eBitDepthUByte:
+	  pixelSize = 1;
+	  break;
+	case OFX::eBitDepthUShort:
+	  pixelSize = 2;
+	  break;
+	case OFX::eBitDepthFloat:
+	  pixelSize = 4;
+	  break;
+	default:
+	  break;
+	}
+	switch (components) {
+	case OFX::ePixelComponentRGBA:
+	  pixelSize *= 4;
+	  break;
+	case OFX::ePixelComponentRGB:
+	  pixelSize *= 3;
+	  break;
+	default:
+	  break;
+	}
+	// User parameters
+	OutputBufferProcessParams params = getProcessParams( args.time );
+
+
+
+	if( src->isLinearBuffer() && dst->isLinearBuffer() )
+	{
+	  // Two linear buffers. No copy needed.
+		imageDataBytes = dst->getBoundsImageDataBytes();
+		if( imageDataBytes )
+		{
+		        rawImage = new char[imageDataBytes];
+			TUTTLE_TCOUT( (long int)rawImage << std::endl);
+			dataSrcPtr = src->getPixelAddress( bounds.x1, bounds.y1 );
+			dataDstPtr = dst->getPixelAddress( bounds.x1, bounds.y1 );
+			memcpy( dataDstPtr, dataSrcPtr, imageDataBytes );
+			rawImage = (char *)dataDstPtr;
+		}
+	}
+	else
+	{
+	  // Non-linear buffer. Copy to linear buffer
+		const std::size_t rowBytesToCopy = dst->getBoundsRowDataBytes();
+		imageDataBytes = rowBytesToCopy*(bounds.y2-bounds.y1);
+		rawImage = new char[imageDataBytes];
+		for( int y = bounds.y1; y < bounds.y2; ++y )
+		{
+			dataSrcPtr = src->getPixelAddress( bounds.x1, y );
+			dataDstPtr = dst->getPixelAddress( bounds.x1, y );
+			memcpy( dataDstPtr, dataSrcPtr, rowBytesToCopy );
+			memcpy( rawImage + rowBytesToCopy*(y-bounds.y1),
+				dataSrcPtr, rowBytesToCopy);
+		}
+	}
+
+	if (params._callbackPtr != NULL) {
+	  params._callbackPtr(args.time, params._callbackCustomDataPtr,rawImage,
+			      bounds.x2-bounds.x1, bounds.y2-bounds.y1, pixelSize*(bounds.x2-bounds.x1),
+			      depth, components, field);
+	}
+	if ((void *)rawImage != dataDstPtr)
+	  delete rawImage;
+}
+
+
+}
+}
+}

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.hpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.hpp
@@ -1,0 +1,50 @@
+#ifndef _TUTTLE_PLUGIN_OUTPUTBUFFER_PLUGIN_HPP_
+#define _TUTTLE_PLUGIN_OUTPUTBUFFER_PLUGIN_HPP_
+
+#include "OutputBufferDefinitions.hpp"
+
+#include <tuttle/plugin/ImageEffectGilPlugin.hpp>
+
+extern "C" {
+  typedef void (*OutCallbackPtr)(OfxTime time, void* outputCustomData, void *rawdata, int width, int height, int rowSizeBytes, OFX::EBitDepth bitDepth, OFX::EPixelComponent components, OFX::EField field);
+  typedef void* CallbackCustomDataPtr;
+}
+
+namespace tuttle {
+namespace plugin {
+namespace outputBuffer {
+
+struct OutputBufferProcessParams
+{
+  OutCallbackPtr _callbackPtr;
+  CallbackCustomDataPtr _callbackCustomDataPtr;
+};
+
+/**
+ * @brief OutputBuffer plugin
+ */
+class OutputBufferPlugin : public OFX::ImageEffect
+{
+public:
+        OutputBufferPlugin( OfxImageEffectHandle handle );
+
+        OutputBufferProcessParams getProcessParams( const OfxTime time ) const;
+
+	void render( const OFX::RenderArguments& args );
+
+public:
+	/// @group Attributes
+	/// @{
+	OFX::Clip* _clipSrc;       ///< Input image clip
+  	OFX::Clip* _clipDst;       ///< Ouput image clip
+
+        OFX::StringParam* _paramOutputCallbackPointer;
+	OFX::StringParam* _paramOutputCallbackCustomData;
+	/// @}
+};
+
+}
+}
+}
+
+#endif

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.cpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.cpp
@@ -1,0 +1,114 @@
+#include "OutputBufferPluginFactory.hpp"
+#include "OutputBufferPlugin.hpp"
+#include "OutputBufferDefinitions.hpp"
+#include "ofxsImageEffect.h"
+
+#include <limits>
+
+namespace tuttle {
+namespace plugin {
+namespace outputBuffer {
+
+static const bool kSupportTiles = false;
+
+
+/**
+ * @brief Function called to describe the plugin main features.
+ * @param[in, out] desc Effect descriptor
+ */
+void OutputBufferPluginFactory::describe( OFX::ImageEffectDescriptor& desc )
+{
+	desc.setLabels(
+		"TuttleOutputBuffer",
+		"OutputBuffer",
+		"OutputBuffer" );
+	desc.setPluginGrouping( "tuttle/image/io" );
+
+	desc.setDescription(
+		"This is a DANGEROUS plugin dedicated to developers.\n"
+		"\n"
+		"WARNING: If you put a wrong value, you will crash your application.\n"
+		"\n"
+		"It allows users to read an image buffer directly from the graph." );
+
+	// add the supported contexts, only filter at the moment
+	desc.addSupportedContext( OFX::eContextWriter );
+	desc.addSupportedContext( OFX::eContextGeneral );
+
+	// add supported pixel depths
+	desc.addSupportedBitDepth( OFX::eBitDepthUByte );
+	desc.addSupportedBitDepth( OFX::eBitDepthUShort );
+	desc.addSupportedBitDepth( OFX::eBitDepthFloat );
+
+	// plugin flags
+	desc.setSupportsTiles( kSupportTiles );
+	desc.setRenderThreadSafety( OFX::eRenderFullySafe );
+	desc.setSupportsMultipleClipDepths( true );
+	desc.setSupportsMultiResolution( false );
+	desc.setSupportsTiles( false );
+}
+
+/**
+ * @brief Function called to describe the plugin controls and features.
+ * @param[in, out]   desc       Effect descriptor
+ * @param[in]        context    Application context
+ */
+void OutputBufferPluginFactory::describeInContext( OFX::ImageEffectDescriptor& desc,
+                                                  OFX::EContext context )
+{
+	OFX::ClipDescriptor* srcClip = desc.defineClip( kOfxImageEffectSimpleSourceClipName );
+
+	srcClip->addSupportedComponent( OFX::ePixelComponentRGBA );
+	srcClip->addSupportedComponent( OFX::ePixelComponentRGB );
+	srcClip->addSupportedComponent( OFX::ePixelComponentAlpha );
+	srcClip->setSupportsTiles( kSupportTiles );
+
+	OFX::ClipDescriptor* dstClip = desc.defineClip( kOfxImageEffectOutputClipName );
+	dstClip->addSupportedComponent( OFX::ePixelComponentRGBA );
+	dstClip->addSupportedComponent( OFX::ePixelComponentRGB );
+	dstClip->addSupportedComponent( OFX::ePixelComponentAlpha );
+	dstClip->setSupportsTiles( kSupportTiles );
+
+	OFX::StringParamDescriptor* callbackPointer = desc.defineStringParam( kParamOutputCallbackPointer );
+	callbackPointer->setLabel( "Callback Pointer" );
+	callbackPointer->setHint(
+		"This parameter represents a pointer to a function.\n"
+		"WARNING:\n"
+		" - Your application will crash if you set an invalid value here.\n"
+		);
+	callbackPointer->setCacheInvalidation( OFX::eCacheInvalidateValueAll );
+	callbackPointer->setIsPersistant( false );
+	callbackPointer->setAnimates( false );
+	callbackPointer->setDefault( "" );
+	
+	OFX::StringParamDescriptor* callbackCustomData = desc.defineStringParam( kParamOutputCallbackCustomData );
+	callbackCustomData->setLabel( "Callback Custom Data Pointer" );
+	callbackCustomData->setHint(
+		"This parameter represent a pointer to a custom data which is given to the callback function.\n"
+		"WARNING:\n"
+		" - Your application could crash if you set an invalid value here.\n"
+		);
+	callbackCustomData->setCacheInvalidation( OFX::eCacheInvalidateValueAll );
+	callbackCustomData->setIsPersistant( false );
+	callbackCustomData->setAnimates( false );
+	callbackCustomData->setDefault( "" );
+
+
+}
+
+/**
+ * @brief Function called to create a plugin effect instance
+ * @param[in] handle  Effect handle
+ * @param[in] context Application context
+ * @return  plugin instance
+ */
+OFX::ImageEffect* OutputBufferPluginFactory::createInstance( OfxImageEffectHandle handle,
+                                                            OFX::EContext context )
+{
+	return new OutputBufferPlugin( handle );
+}
+
+}
+}
+}
+

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.hpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.hpp
@@ -1,0 +1,18 @@
+#ifndef _TUTTLE_PLUGIN_OUTPUTBUFFERPLUGINFACTORY_HPP_
+#define _TUTTLE_PLUGIN_OUTPUTBUFFERPLUGINFACTORY_HPP_
+
+#include <ofxsImageEffect.h>
+
+namespace tuttle {
+namespace plugin {
+namespace outputBuffer {
+
+mDeclarePluginFactory( OutputBufferPluginFactory, { }, { } );
+
+}
+}
+}
+
+#endif
+
+


### PR DESCRIPTION
Closes #96

Only callbacks are implemented. The use of NULL terminated strings limits the usefulness of the string param passing method used in the InputBuffer.
