### PR TITLE
OutputBuffer: added support for max_image_size

### DIFF
--- a/applications/example/python/numpyOutputBuffer.py
+++ b/applications/example/python/numpyOutputBuffer.py
@@ -5,9 +5,44 @@ import numpy
 
 # This is called by Tuttle with the output image data
 def writeImage(time, data, width, height, rowSizeBytes, bitDepth, components, field):
-	# FIXME this assumes 8bit RGB image. Check bitDepth, components, field
-	flatarray = numpy.fromstring(data, numpy.uint8, rowSizeBytes*height)
-	outImage = numpy.array(numpy.flipud(numpy.reshape(flatarray, (height, width, 3))))
+	# Get pixel component type and size
+        if bitDepth == 1:
+            comptype = np.uint8
+            bytes_per_comp = 1
+        elif bitDepth == 2:
+            comptype = np.uint16
+            bytes_per_comp = 2
+        elif bitDepth == 3:
+            comptype = np.float32
+            bytes_per_comp = 4
+        else:
+            raise Exception("Unknown bitDepth getting image from OutputBuffer")
+
+        # FIXME: This doesn't work if rowSizeBytes isn't  a multiple of bytes_per_comp.
+	#        It seems unlikely that rows would be allocated with a different component type
+	#        but it is possible. In that case, each row would have to be allocated separately
+	if rowSizeBytes % bytes_per_comp != 0:
+		raise Exception("Unsupported image layout")
+
+	# Get number of pixel components
+        if components == 0 or components == 3:
+            num_comps = 1
+        elif components == 1:
+            num_comps = 4
+        elif components == 2:
+            num_comps = 3
+        else:
+            raise Exception("Unknown components getting image from OutputBuffer")
+        
+        bytes_per_pixel = bytes_per_comp*num_comps
+
+	# Convert data into numpy array
+        outImage = np.fromstring(data, comptype, (rowSizeBytes/bytes_per_comp)*height)
+        if rowSizeBytes != width*bytes_per_pixel:
+            outImage = np.reshape(outImage,(height, rowSizeBytes/bytes_per_comp))
+            outImage = outImage[0:height,0:width*num_comps]
+        outImage = np.reshape(outImage,(height,width,num_comps))
+
 	Image.fromarray(outImage).save("foo.jpg")
 
 tuttle.Core.instance().preload()

--- a/plugins/image/io/MemoryBuffer/src/mainEntry.cpp
+++ b/plugins/image/io/MemoryBuffer/src/mainEntry.cpp
@@ -1,4 +1,4 @@
-#define OFXPLUGIN_VERSION_MAJOR 0
+#define OFXPLUGIN_VERSION_MAJOR 1
 #define OFXPLUGIN_VERSION_MINOR 0
 
 #include "inputBuffer/InputBufferPluginFactory.hpp"

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferDefinitions.hpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferDefinitions.hpp
@@ -12,6 +12,7 @@ namespace outputBuffer {
 static const std::string kParamOutputCallbackPointer = "callbackPointer";
 static const std::string kParamOutputCustomData = "customData";
 static const std::string kParamOutputCallbackDestroyCustomData = "callbackDestroyCustomData";
+static const std::string kParamMaxImageSize = "max_image_size";
 
 extern "C" {
 	typedef void* CustomDataPtr;

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.hpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPlugin.hpp
@@ -28,18 +28,19 @@ public:
 	void changedParam( const OFX::InstanceChangedArgs& args, const std::string& paramName );
 
 	OutputBufferProcessParams getProcessParams() const;
-
+	bool getRegionOfDefinition( const OFX::RegionOfDefinitionArguments& args, OfxRectD& rod );
+	void getRegionsOfInterest( const OFX::RegionsOfInterestArguments& args, OFX::RegionOfInterestSetter& rois );
 	void render( const OFX::RenderArguments& args );
 
 public:
 	/// @group Attributes
 	/// @{
 	OFX::Clip* _clipSrc;       ///< Input image clip
-	OFX::Clip* _clipDst;       ///< Ouput image clip
 
 	OFX::StringParam* _paramCallbackOutputPointer;
 	OFX::StringParam* _paramCustomData;
 	OFX::StringParam* _paramCallbackDestroyCustomData;
+        OFX::Int2DParam*  _paramMaxImageSize;
 	/// @}
 	
 	CustomDataPtr _tempStoreCustomDataPtr; //< keep track of the previous value

--- a/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.cpp
+++ b/plugins/image/io/MemoryBuffer/src/outputBuffer/OutputBufferPluginFactory.cpp
@@ -9,7 +9,7 @@ namespace tuttle {
 namespace plugin {
 namespace outputBuffer {
 
-static const bool kSupportTiles = false;
+static const bool kSupportTiles = true;
 
 
 /**
@@ -45,7 +45,6 @@ void OutputBufferPluginFactory::describe( OFX::ImageEffectDescriptor& desc )
 	desc.setRenderThreadSafety( OFX::eRenderFullySafe );
 	desc.setSupportsMultipleClipDepths( true );
 	desc.setSupportsMultiResolution( false );
-	desc.setSupportsTiles( false );
 }
 
 /**
@@ -105,7 +104,16 @@ void OutputBufferPluginFactory::describeInContext( OFX::ImageEffectDescriptor& d
 	callbackDestroyCustomData->setAnimates( false );
 	callbackDestroyCustomData->setDefault( "" );
 
-
+	OFX::Int2DParamDescriptor* size = desc.defineInt2DParam( kParamMaxImageSize );
+	size->setLabel( "Maximum Output Image Size" );
+	size->setHint("This is the expected size of the image\n"
+		"The output will never exceed this size.\n"
+		"This param is ignored if either dimension is 0.\n"
+		);
+	size->setRange( 0, 0, std::numeric_limits<int>::max(), std::numeric_limits<int>::max() );
+	size->setIsPersistant( false );
+	size->setAnimates( false );
+	size->setDefault( 0, 0 );
 }
 
 /**


### PR DESCRIPTION
* eliminated redundant memcpy calls
 * updated example to be more robust

<!---
@huboard:{"milestone_order":3.077730070799589e-09}
-->
