### PR TITLE
tuttle host: Set render RoIs for each node

### DIFF
--- a/libraries/tuttle/src/tuttle/host/graph/ProcessVertexAtTimeData.cpp
+++ b/libraries/tuttle/src/tuttle/host/graph/ProcessVertexAtTimeData.cpp
@@ -44,13 +44,10 @@ std::ostream& operator<<( std::ostream& os, const ProcessVertexAtTimeData& vData
 			os << "renderScale:" << vData._nodeData->_renderScale << std::endl;
 
 			os << "clips:" << vData._apiImageEffect._inputsRoI.size() << std::endl;
-			BOOST_FOREACH( const ProcessVertexAtTimeData::ImageEffect::MapClipImageRod::value_type & item, vData._apiImageEffect._inputsRoI )
+			BOOST_FOREACH( const ProcessVertexAtTimeData::ImageEffect::MapClipImageRoI::value_type & item, vData._apiImageEffect._inputsRoI )
 			{
-				if( item.first )
-				{
-					os << "  clip:" << item.first->getName() << std::endl;
-					os << "  roi:" << item.second << std::endl;
-				}
+                          os << "  clip:" << item.first << std::endl;
+                          os << "  roi:" << item.second << std::endl;
 			}
 			break;
 		case INode::eNodeTypeGraph:

--- a/libraries/tuttle/src/tuttle/host/graph/ProcessVertexAtTimeData.hpp
+++ b/libraries/tuttle/src/tuttle/host/graph/ProcessVertexAtTimeData.hpp
@@ -117,8 +117,8 @@ public:
 		OfxRectD _renderRoD; // is it a good thing to store this here ?
 		OfxRectD _renderRoI;
 
-		typedef std::map<tuttle::host::ofx::attribute::OfxhClipImage*, OfxRectD> MapClipImageRod;
-		MapClipImageRod _inputsRoI; ///<< in which the plugin set the RoI it needs for each input clip
+	        typedef std::map<std::string, OfxRectD> MapClipImageRoI;
+		MapClipImageRoI _inputsRoI; ///<< in which the plugin set the RoI it needs for each input clip
 
 	} _apiImageEffect;
 	/// @}

--- a/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
@@ -876,7 +876,7 @@ void OfxhImageEffectNode::getRegionOfDefinitionAction( OfxTime   time,
 void OfxhImageEffectNode::getRegionOfInterestAction( OfxTime time,
 						     OfxPointD renderScale,
 						     const OfxRectD& roi,
-						     std::map<attribute::OfxhClipImage*, OfxRectD>& rois ) const OFX_EXCEPTION_SPEC
+						     std::map<std::string, OfxRectD>& rois ) const OFX_EXCEPTION_SPEC
 {
 	// reset the map
 	rois.clear();
@@ -896,7 +896,7 @@ void OfxhImageEffectNode::getRegionOfInterestAction( OfxTime time,
 				{
 					/// @todo tuttle: how to support size on generators... check if this is correct in all cases.
 					OfxRectD roi = clip.second->fetchRegionOfDefinition( time );
-					rois[clip.second] = roi;
+					rois[clip.second->getName()] = roi;
 				}
 			}
 		}
@@ -981,12 +981,12 @@ void OfxhImageEffectNode::getRegionOfInterestAction( OfxTime time,
 
 						// clamp it to the clip's rod
 						thisRoi          = clamp( thisRoi, inputsRodIntersection );
-						rois[clip.second] = thisRoi;
+						rois[clip.second->getName()] = thisRoi;
 					}
 					else
 					{
 						/// not supporting tiles on this input, so set it to the rod
-						rois[clip.second] = inputsRodIntersection;
+                                                rois[clip.second->getName()] = inputsRodIntersection;
 					}
 				}
 			}

--- a/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.hpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.hpp
@@ -364,7 +364,7 @@ public:
 	virtual void getRegionOfInterestAction( OfxTime time,
 	                                        OfxPointD renderScale,
 	                                        const OfxRectD& roi,
-	                                        std::map<attribute::OfxhClipImage*, OfxRectD>& rois ) const OFX_EXCEPTION_SPEC;
+	                                        std::map<std::string, OfxRectD>& rois ) const OFX_EXCEPTION_SPEC;
 
 	// get frames needed to render the given frame
 	virtual void getFramesNeededAction( OfxTime   time,


### PR DESCRIPTION
previously, the RoIs were calculated as part of the preprocess 2 step, but they went unused