### PR TITLE
Added check for empty _dateAtTime in getProjectSize and getProjectExtent

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
@@ -130,13 +130,21 @@ void ImageEffectNode::vmessage( const char* type,
 // get the project size in CANONICAL pixels, so PAL SD return 768, 576
 void ImageEffectNode::getProjectSize( double& xSize, double& ySize ) const
 {
-	OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
-	xSize = rod.x2 - rod.x1;
-	ySize = rod.y2 - rod.y1;
-	if (xSize < 1 || ySize < 1)
+	if (_dataAtTime.size() == 0 )
 	  {
-	    xSize = 720;
-	    ySize = 576;
+	       	xSize = 720;
+       		ySize = 576;		
+	  }
+	else
+	  {
+		OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
+		xSize = rod.x2 - rod.x1;
+		ySize = rod.y2 - rod.y1;
+		if (xSize < 1 || ySize < 1)
+		  {
+	    		xSize = 720;
+	    		ySize = 576;
+		  }
 	  }
 }
 
@@ -150,13 +158,21 @@ void ImageEffectNode::getProjectOffset( double& xOffset, double& yOffset ) const
 // get the project extent in CANONICAL pixels, so PAL SD return 768, 576
 void ImageEffectNode::getProjectExtent( double& xSize, double& ySize ) const
 {
-	OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
-	xSize = rod.x2 - rod.x1;
-	ySize = rod.y2 - rod.y1;
-	if (xSize < 1 || ySize < 1)
+	if (_dataAtTime.size() == 0 )
 	  {
-	    xSize = 720;
-	    ySize = 576;
+	       	xSize = 720;
+       		ySize = 576;		
+	  }
+	else
+	  {
+		OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
+		xSize = rod.x2 - rod.x1;
+		ySize = rod.y2 - rod.y1;
+		if (xSize < 1 || ySize < 1)
+		  {
+	    		xSize = 720;
+	    		ySize = 576;
+		  }
 	  }
 }
 


### PR DESCRIPTION
In some cases getProjectSize and getProjectExtent can be called when _dateAtTime is empty, thus throwing an exception. To avoid this I've added a check for a size of 0, if true the functions will hand back the old PAL width/height, avoiding the exception.
