### PR TITLE
FFMpegReader: Add an option to ignore the input SAR

### DIFF
--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderDefinitions.hpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderDefinitions.hpp
@@ -9,6 +9,8 @@ namespace plugin {
 namespace ffmpeg {
 namespace reader {
 
+static const std::string kParamKeepSAR = "keepSAR";
+
 }
 }
 }

--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.cpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.cpp
@@ -25,6 +25,7 @@ FFMpegReaderPlugin::FFMpegReaderPlugin( OfxImageEffectHandle handle )
 	_clipDst       = fetchClip( kOfxImageEffectOutputClipName );
 	_paramFilepath = fetchStringParam( kTuttlePluginFilename );
 	_paramBitDepth = fetchChoiceParam( kTuttlePluginBitDepth );
+	_paramKeepSAR  = fetchBooleanParam( kParamKeepSAR );
 }
 
 FFMpegReaderParams FFMpegReaderPlugin::getProcessParams() const
@@ -76,7 +77,8 @@ void FFMpegReaderPlugin::getClipPreferences( OFX::ClipPreferencesSetter& clipPre
 		return;
 
 	// options depending on input file
-	clipPreferences.setPixelAspectRatio( *_clipDst, _reader.aspectRatio() );
+	bool keepSAR = _paramKeepSAR->getValue();
+	clipPreferences.setPixelAspectRatio( *_clipDst, keepSAR ? _reader.aspectRatio() : 1.0 );
 	clipPreferences.setOutputFrameRate( _reader.fps() );
 
 	// Setup fielding
@@ -117,8 +119,10 @@ bool FFMpegReaderPlugin::getRegionOfDefinition( const OFX::RegionOfDefinitionArg
 	if( !ensureVideoIsOpen() )
 		return false;
 
+	bool keepSAR = _paramKeepSAR->getValue();
+
 	rod.x1 = 0;
-	rod.x2 = _reader.width() * _reader.aspectRatio();
+	rod.x2 = _reader.width() * (keepSAR ? _reader.aspectRatio() : 1.0);
 	rod.y1 = 0;
 	rod.y2 = _reader.height();
 	return true;

--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.hpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.hpp
@@ -43,6 +43,7 @@ public:
 	OFX::Clip* _clipDst;              ///< Destination image clip
 
 	OFX::StringParam* _paramFilepath; ///< video filepath
+	OFX::BooleanParam* _paramKeepSAR; ///< Keep sample aspect ratio
 
 	bool _errorInFile;
 	VideoFFmpegReader _reader;

--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPluginFactory.cpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPluginFactory.cpp
@@ -85,6 +85,11 @@ void FFMpegReaderPluginFactory::describeInContext( OFX::ImageEffectDescriptor& d
 	dstClip->addSupportedComponent( OFX::ePixelComponentAlpha );
 	dstClip->setSupportsTiles( kSupportTiles );
 
+	OFX::BooleanParamDescriptor* keepSAR = desc.defineBooleanParam( kParamKeepSAR );
+	keepSAR->setLabel( "Keep input SAR" );
+	keepSAR->setDefault( true );
+	keepSAR->setHint( "Keep input sample aspect ratio." );
+
 	describeReaderParamsInContext( desc, context );
 }
 


### PR DESCRIPTION
Sometimes, we may want to drop thhis information.
