### PR TITLE
FFMpegReader: Add options to use a custom SAR (v2)

### DIFF
--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderDefinitions.hpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderDefinitions.hpp
@@ -10,6 +10,7 @@ namespace ffmpeg {
 namespace reader {
 
 static const std::string kParamKeepSAR = "keepSAR";
+static const std::string kParamCustomSAR = "customSAR";
 
 }
 }

--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.hpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPlugin.hpp
@@ -29,6 +29,7 @@ public:
 
 	FFMpegReaderParams getProcessParams() const;
 
+	void updateVisibleTools();
 	void changedParam( const OFX::InstanceChangedArgs& args, const std::string& paramName );
 	bool getRegionOfDefinition( const OFX::RegionOfDefinitionArguments& args, OfxRectD& rod );
 	void getClipPreferences( OFX::ClipPreferencesSetter& clipPreferences );
@@ -44,6 +45,7 @@ public:
 
 	OFX::StringParam* _paramFilepath; ///< video filepath
 	OFX::BooleanParam* _paramKeepSAR; ///< Keep sample aspect ratio
+	OFX::DoubleParam* _paramCustomSAR; ///< Custom SAR to use
 
 	bool _errorInFile;
 	VideoFFmpegReader _reader;

--- a/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPluginFactory.cpp
+++ b/plugins/image/io/FFMpeg/src/reader/FFMpegReaderPluginFactory.cpp
@@ -90,6 +90,11 @@ void FFMpegReaderPluginFactory::describeInContext( OFX::ImageEffectDescriptor& d
 	keepSAR->setDefault( true );
 	keepSAR->setHint( "Keep input sample aspect ratio." );
 
+	OFX::DoubleParamDescriptor* customSAR = desc.defineDoubleParam( kParamCustomSAR );
+	customSAR->setLabel( "Custom SAR" );
+	customSAR->setDefault( 1.0 );
+	customSAR->setHint( "Set a custom SAR for the input image." );
+
 	describeReaderParamsInContext( desc, context );
 }
 


### PR DESCRIPTION
It works from the command line and python bindings.

I don't have any interactive application to test with though.
