### PR TITLE
Fix getProjectSize & getProjectExtent,increased the timeline to 99999

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
@@ -167,7 +167,7 @@ void ImageEffectNode::getProjectSize( double& xSize, double& ySize ) const
 	  }
 	else
 	  {
-		OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
+		OfxRectD rod = getData( _dataAtTime.size()-1 )._apiImageEffect._renderRoD;
 		xSize = rod.x2 - rod.x1;
 		ySize = rod.y2 - rod.y1;
 		if (xSize < 1 || ySize < 1)
@@ -195,7 +195,7 @@ void ImageEffectNode::getProjectExtent( double& xSize, double& ySize ) const
 	  }
 	else
 	  {
-		OfxRectD rod = getFirstData()._apiImageEffect._renderRoD;
+		OfxRectD rod = getData( _dataAtTime.size()-1 )._apiImageEffect._renderRoD;
 		xSize = rod.x2 - rod.x1;
 		ySize = rod.y2 - rod.y1;
 		if (xSize < 1 || ySize < 1)
@@ -215,7 +215,7 @@ double ImageEffectNode::getProjectPixelAspectRatio() const
 // we are only 25 frames
 double ImageEffectNode::getEffectDuration() const
 {
-	return 25.0;
+	return 99999.0;
 }
 
 double ImageEffectNode::getFrameRate() const
@@ -365,7 +365,7 @@ void ImageEffectNode::timelineGotoTime( double t )
 void ImageEffectNode::timelineGetBounds( double& t1, double& t2 )
 {
 	t1 = 0;
-	t2 = 25;
+	t2 = 99999;
 }
 
 /// override to get frame range of the effect


### PR DESCRIPTION
The code getProjectSize and getProjectExtent would start to hand back incorrect/corrupt frame sizes when processing a long clip. By changing from getFirstData to getData( _dataAtTime.size()-1 ) the values return remain stable.

The effect duration and timeline bounds where changed from 25 to 99999 as having such a low figure caused problems with effects that processed more than 25 frames.
