### PR TITLE
Added default kOfxPropTime to outArgs in isIdentityAction

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
@@ -1148,6 +1148,8 @@ bool OfxhImageEffectNode::isIdentityAction( OfxTime&           time,
 
 	property::OfxhSet outArgs( outStuff );
 
+	outArgs.setDoubleProperty( kOfxPropTime, time );
+
 	OfxStatus status = mainEntry( kOfxImageEffectActionIsIdentity,
 				      this->getHandle(),
 				      &inArgs,


### PR DESCRIPTION
According to the OpenFX documentation the time for the outArgs should default to the same value as the inArgs. This can cause problems as effects may not set the outArgs because they will assume kOfxPropTime will be set by default.
