### PR TITLE
declare exception tags as empty struct to fix visibility problems.

### DIFF
--- a/libraries/tuttle/src/tuttle/common/exceptions.hpp
+++ b/libraries/tuttle/src/tuttle/common/exceptions.hpp
@@ -1,6 +1,21 @@
 #ifndef _TUTTLE_COMMON_EXCEPTION_HPP_
 #define _TUTTLE_COMMON_EXCEPTION_HPP_
 
+namespace boost {
+  struct errinfo_file_name_ {};
+}
+namespace tuttle { namespace exception {
+    struct tag_userMessage {};
+    struct tag_devMessage {};
+    struct tag_backtraceMessage {};
+    struct tag_ofxContext {};
+    struct tag_ofxApi {};
+    struct tag_pluginIdentifier {};
+    struct tag_pluginName {};
+    struct tag_nodeName {};
+    struct tag_time {};
+}}
+
 #include "utils/boost_error_info_sstream.hpp"
 #include "utils/backtrace.hpp"
 


### PR DESCRIPTION
typeinfo and typeinfo name were visible, even when compiling with -fvisibility=hidden,
for the following types:
boost::errinfo_file_name_*
tuttle::exception::tag_ofxApi*
tuttle::exception::tag_nodeName*
tuttle::exception::tag_devMessage*
tuttle::exception::tag_ofxContext*
tuttle::exception::tag_userMessage*
tuttle::exception::tag_pluginIdentifier*
tuttle::exception::tag_time*

an alternative fix, which adds #pragmas, is adding this block at the beginning
of libraries/tuttle/src/tuttle/common/exceptions.hpp:
 #if defined(**GNUC**)
 # if (**GNUC** == 4 && **GNUC_MINOR** >= 1) || (**GNUC** > 4)
 #  pragma GCC visibility push (default)
 # endif
 #endif
namespace boost {
  struct errinfo_file_name_;
}
namespace tuttle { namespace exception {
  struct tag_userMessage;
  struct tag_devMessage;
  struct tag_backtraceMessage;
  struct tag_ofxContext;
  struct tag_ofxAp;
  struct tag_pluginIdentifier;
  struct tag_pluginName;
  struct tag_nodeName;
  struct tag_time;
}}
 #if defined(**GNUC**)
 # if (**GNUC** == 4 && **GNUC_MINOR** >= 1) || (**GNUC** > 4)
 #  pragma GCC visibility pop
 # endif
 #endif
