### PR TITLE
fix OpenGL header name on OSX

### DIFF
--- a/libraries/tuttle/src/tuttle/plugin/opengl/gl.h
+++ b/libraries/tuttle/src/tuttle/plugin/opengl/gl.h
@@ -1,7 +1,7 @@
 #include <tuttle/common/system/windows/windows.h>
 
 #ifdef __APPLE__
- #include <GL/gl.h>
+ #include <OpenGL/gl.h>
 #else
  #include <GL/gl.h>
 #endif


### PR DESCRIPTION
I forgot this one in my previous pull request.
On OSX, X11 OpenGL headers should not be used.
