### PR TITLE
Host: abstract class IProgressHandle not required

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ComputeOptions.hpp
+++ b/libraries/tuttle/src/tuttle/host/ComputeOptions.hpp
@@ -21,12 +21,12 @@ class IProgressHandle
 public:
 	virtual ~IProgressHandle() = 0;
 
-	virtual void beginSequence() = 0;
-	virtual void beginFrame() = 0;
-	virtual void setupAtTime() = 0;
-	virtual void processAtTime() = 0;
-	virtual void endFrame() = 0;
-	virtual void endSequence() = 0;
+	virtual void beginSequence() {}
+	virtual void beginFrame() {}
+	virtual void setupAtTime() {}
+	virtual void processAtTime() {}
+	virtual void endFrame() {}
+	virtual void endSequence() {}
 };
 
 struct TimeRange


### PR DESCRIPTION
Fix problem in python binding, with examples inherit from IProgressHandle and not implemented all functions.
