### PR TITLE
AudioVideo: call parents function when begin/render/endSequenceRender

### DIFF
--- a/plugins/image/io/AudioVideo/src/reader/AVReaderPlugin.cpp
+++ b/plugins/image/io/AudioVideo/src/reader/AVReaderPlugin.cpp
@@ -474,6 +474,8 @@ bool AVReaderPlugin::getRegionOfDefinition( const OFX::RegionOfDefinitionArgumen
 
 void AVReaderPlugin::beginSequenceRender( const OFX::BeginSequenceRenderArguments& args )
 {
+	ReaderPlugin::beginSequenceRender( args );
+
 	ensureVideoIsOpen();
 
 	_inputFile->setProfile( _paramFormatCustom.getCorrespondingProfile() );

--- a/plugins/image/io/AudioVideo/src/writer/AVWriterPlugin.cpp
+++ b/plugins/image/io/AudioVideo/src/writer/AVWriterPlugin.cpp
@@ -1041,6 +1041,8 @@ void AVWriterPlugin::cleanVideoAndAudio()
  */
 void AVWriterPlugin::beginSequenceRender( const OFX::BeginSequenceRenderArguments& args )
 {
+	WriterPlugin::beginSequenceRender( args );
+
 	// Before new render
 	cleanVideoAndAudio();
 	initOutput();
@@ -1078,6 +1080,7 @@ void AVWriterPlugin::endSequenceRender( const OFX::EndSequenceRenderArguments& a
 	if( ! _initWrap || ! _initVideo )
 		return;
 	
+	WriterPlugin::endSequenceRender( args );
 	_outputFile->endWrap();
 }
 


### PR DESCRIPTION
This fixes avwriter when try to write a file with a non exiting path.