### PR TITLE
CMake: the install rule does not depend on all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ if(TUTTLE_PRODUCTION)
   add_definitions(-DTUTTLE_PRODUCTION)
 endif()
 
+# The install rule does not depend on all, i.e. everything will not be built before installing
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
+
 # Create an alias for all OFX plugins.
 add_custom_target(ofxplugins)
 

--- a/cmake/TuttleMacros.cmake
+++ b/cmake/TuttleMacros.cmake
@@ -33,7 +33,7 @@ function(tuttle_install_shared_libs LIBRARIES)
             get_filename_component(realpath ${lib} REALPATH) 
             tuttle_get_library_soname(${realpath} SONAME)
             message("will copy and rename ${realpath} to ${SONAME}") 
-            install(FILES ${realpath} DESTINATION lib/ RENAME ${SONAME} NAMELINK_SKIP)
+            install(FILES ${realpath} DESTINATION lib/ RENAME ${SONAME} NAMELINK_SKIP OPTIONAL)
         endif()
     endforeach(lib ${LIBRARIES})
 endfunction(tuttle_install_shared_libs )
@@ -114,7 +114,7 @@ function(tuttle_ofx_plugin_target PLUGIN_NAME)
         # http://openfx.sourceforge.net/Documentation/1.3/Reference/ch02s02.html
         set(OFX_PLUGIN_ROOT "${CMAKE_INSTALL_PREFIX}/OFX/${PLUGIN_NAME}${_plugin_version_suffix}.ofx.bundle/Contents")
         tuttle_ofx_architecture(OFX_ARCH)
-        install(DIRECTORY Resources DESTINATION ${OFX_PLUGIN_ROOT})
+        install(DIRECTORY Resources DESTINATION ${OFX_PLUGIN_ROOT} OPTIONAL)
         install(TARGETS ${PLUGIN_NAME} 
             DESTINATION ${OFX_PLUGIN_ROOT}/${OFX_ARCH} OPTIONAL)
 
@@ -238,7 +238,7 @@ function(tuttle_add_executable TARGET SOURCES)
         endif(APPLE)
 
         # Install
-        install(TARGETS ${TARGET} DESTINATION bin)
+        install(TARGETS ${TARGET} DESTINATION bin OPTIONAL)
     endif(TuttleBoost_FOUND)
 endfunction(tuttle_add_executable)
 

--- a/libraries/tuttle/CMakeLists.txt
+++ b/libraries/tuttle/CMakeLists.txt
@@ -110,6 +110,8 @@ if (TuttleBoost_FOUND)
     DESTINATION "include"
     FILES_MATCHING
     PATTERN "*.hpp"
+    PATTERN "*.h"
+    PATTERN "*.tcc"
     PATTERN "*.i"
   )
 

--- a/libraries/tuttle/CMakeLists.txt
+++ b/libraries/tuttle/CMakeLists.txt
@@ -102,6 +102,8 @@ if (TuttleBoost_FOUND)
 
   # Install tuttle host library in INSTALL_PREFIX/lib/
   install(TARGETS tuttleHost DESTINATION lib/ OPTIONAL)
+  install(TARGETS tuttleCommon DESTINATION lib/ OPTIONAL)
+  install(TARGETS tuttlePluginLib DESTINATION lib/ OPTIONAL)
   install(TARGETS sequenceParser DESTINATION lib/ OPTIONAL)
 
   # Install tuttle host headers

--- a/libraries/tuttle/CMakeLists.txt
+++ b/libraries/tuttle/CMakeLists.txt
@@ -101,8 +101,8 @@ if (TuttleBoost_FOUND)
 
 
   # Install tuttle host library in INSTALL_PREFIX/lib/
-  install(TARGETS tuttleHost DESTINATION lib/)
-  install(TARGETS sequenceParser DESTINATION lib/)
+  install(TARGETS tuttleHost DESTINATION lib/ OPTIONAL)
+  install(TARGETS sequenceParser DESTINATION lib/ OPTIONAL)
 
   # Install tuttle host headers
   install(
@@ -170,12 +170,12 @@ if (TuttleBoost_FOUND)
 
     # Install python libs and wrapper in INSTALL_PREFIX/lib/python
     install(TARGETS ${SWIG_MODULE_tuttle_REAL_NAME} 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle OPTIONAL)
     install(FILES ${CMAKE_BINARY_DIR}/libraries/tuttle/tuttle.py 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle OPTIONAL)
     file(WRITE "__init__.py" "")
     install(FILES "__init__.py" 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pyTuttle OPTIONAL)
 
     # pySequenceParser
     set(SEQUENCEPARSER_PYTHON_BINDING_FILE ../sequenceParser/src/sequenceParser.i)
@@ -198,12 +198,12 @@ if (TuttleBoost_FOUND)
 
     # Install python libs and wrapper in INSTALL_PREFIX/lib/python
     install(TARGETS ${SWIG_MODULE_sequenceParser_REAL_NAME} 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser OPTIONAL)
     install(FILES ${CMAKE_BINARY_DIR}/libraries/tuttle/sequenceParser.py 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser OPTIONAL)
     file(WRITE "__init__.py" "")
     install(FILES "__init__.py" 
-        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser)
+        DESTINATION lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser OPTIONAL)
 
   else(SWIG_FOUND)
     message("SWIG not found, will not build python bindings")


### PR DESCRIPTION
* Everything will not be built before installing.
* Warning: some files (which not need to be compiled) will still be
installed, no matter your targets.