### PR TITLE
Host: kOfxImageEffectPropFrameStep is a double

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ImageEffectNode.cpp
@@ -376,7 +376,7 @@ void ImageEffectNode::timelineGetBounds( double& t1, double& t2 )
 /// override to get frame range of the effect
 void ImageEffectNode::beginSequenceRenderAction( OfxTime   startFrame,
 					 OfxTime   endFrame,
-					 OfxTime   step,
+					 double    step,
 					 bool      interactive,
 					 OfxPointD renderScale ) OFX_EXCEPTION_SPEC
 {

--- a/libraries/tuttle/src/tuttle/host/ImageEffectNode.hpp
+++ b/libraries/tuttle/src/tuttle/host/ImageEffectNode.hpp
@@ -255,7 +255,7 @@ public:
 
 	void beginSequenceRenderAction( OfxTime   startFrame,
 	                        OfxTime   endFrame,
-	                        OfxTime   step,
+	                        double    step,
 	                        bool      interactive,
 	                        OfxPointD renderScale ) OFX_EXCEPTION_SPEC;
 

--- a/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.cpp
@@ -623,7 +623,7 @@ void OfxhImageEffectNode::endInstanceEditAction() OFX_EXCEPTION_SPEC
 
 void OfxhImageEffectNode::beginSequenceRenderAction( OfxTime   startFrame,
 					     OfxTime   endFrame,
-					     OfxTime   step,
+					     double    step,
 					     bool      interactive,
 					     OfxPointD renderScale ) OFX_EXCEPTION_SPEC
 {
@@ -683,7 +683,7 @@ void OfxhImageEffectNode::renderAction( OfxTime            time,
 
 void OfxhImageEffectNode::endSequenceRenderAction( OfxTime   startFrame,
 					   OfxTime   endFrame,
-					   OfxTime   step,
+					   double    step,
 					   bool      interactive,
 					   OfxPointD renderScale ) OFX_EXCEPTION_SPEC
 {

--- a/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.hpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/OfxhImageEffectNode.hpp
@@ -331,7 +331,7 @@ public:
 	// render action
 	virtual void beginSequenceRenderAction( OfxTime   startFrame,
 	                                OfxTime   endFrame,
-	                                OfxTime   step,
+	                                double    step,
 	                                bool      interactive,
 	                                OfxPointD renderScale ) OFX_EXCEPTION_SPEC;
 
@@ -342,7 +342,7 @@ public:
 
 	virtual void endSequenceRenderAction( OfxTime   startFrame,
 	                              OfxTime   endFrame,
-	                              OfxTime   step,
+	                              double    step,
 	                              bool      interactive,
 	                              OfxPointD renderScale ) OFX_EXCEPTION_SPEC;
 


### PR DESCRIPTION
According to the OFX documentation:
The frame step used for a sequence of renders
- Type - double X 1
- Property Set - an in argument for the
::kOfxImageEffectActionBeginSequenceRender action (read only)
- Valid Values - can be any positive value, but typically
   - 1 for frame based material
   - 0.5 for field based material