### PR TITLE
NLMDenoiser: reduce default region value

### DIFF
--- a/plugins/image/process/filter/NlmDenoiser/src/NLMDenoiserDefinitions.hpp
+++ b/plugins/image/process/filter/NlmDenoiser/src/NLMDenoiserDefinitions.hpp
@@ -34,7 +34,7 @@ const int kParamDefaultPatchSizeValue = 2;
 const int kParamDefaultBandwidthValueR = 3;
 const int kParamDefaultBandwidthValueG = 4;
 const int kParamDefaultBandwidthValueB = 10;
-const int kParamDefaultRegionValue = 8;
+const int kParamDefaultRegionValue = 4;
 const int kParamDefaultDepth = 1;
 
 }

--- a/plugins/image/process/filter/NlmDenoiser/src/mainEntry.cpp
+++ b/plugins/image/process/filter/NlmDenoiser/src/mainEntry.cpp
@@ -1,5 +1,5 @@
 #define OFXPLUGIN_VERSION_MAJOR 2
-#define OFXPLUGIN_VERSION_MINOR 2
+#define OFXPLUGIN_VERSION_MINOR 3
 
 #include <tuttle/plugin/Plugin.hpp>
 #include "NLMDenoiserPluginFactory.hpp"


### PR DESCRIPTION
* Since the algo has a complexity of (n^4), a too high default value can
produce a process that will never end (depending on your system and/or
host).
* Fix #401
* Thanks for your help @edubois ;)