### PR TITLE
Writers: add common parameter 'copyToOutput'

### DIFF
--- a/libraries/tuttle/src/tuttle/plugin/context/WriterDefinition.hpp
+++ b/libraries/tuttle/src/tuttle/plugin/context/WriterDefinition.hpp
@@ -22,6 +22,7 @@ enum EParamWriterExistingFile
 
 static const std::string kParamWriterRender         = "render";
 static const std::string kParamWriterRenderAlways   = "renderAlways";
+static const std::string kParamWriterCopyToOutput = "copyToOutput";
 static const std::string kParamWriterForceNewRender = "forceNewRender";
 
 static const std::string kParamPremultiplied      = "premultiplied";

--- a/libraries/tuttle/src/tuttle/plugin/context/WriterPlugin.hpp
+++ b/libraries/tuttle/src/tuttle/plugin/context/WriterPlugin.hpp
@@ -101,6 +101,7 @@ public:
 	OFX::PushButtonParam* _paramRenderButton; ///< Render push button
 	OFX::StringParam*     _paramFilepath; ///< Target file path
 	OFX::BooleanParam*    _paramRenderAlways;
+	OFX::BooleanParam*    _paramCopyToOutput; ///< Copy the image buffer to the output clip
 	OFX::ChoiceParam*     _paramBitDepth;
 	OFX::BooleanParam*    _paramPremult;
 	OFX::ChoiceParam*     _paramExistingFile;

--- a/libraries/tuttle/src/tuttle/plugin/context/WriterPluginFactory.hpp
+++ b/libraries/tuttle/src/tuttle/plugin/context/WriterPluginFactory.hpp
@@ -52,7 +52,12 @@ void describeWriterParamsInContext( OFX::ImageEffectDescriptor& desc,
 	}
 	//existingFile->appendOption( kParamWriterExistingFile_reader ); // TODO: not implemented yet.
 	existingFile->setDefault( eParamWriterExistingFile_overwrite );
-	
+
+	OFX::BooleanParamDescriptor* copyToOutput = desc.defineBooleanParam( kParamWriterCopyToOutput );
+	copyToOutput->setLabel( "Copy buffer to output" );
+	copyToOutput->setHint( "This is only useful if you connect nodes to the output clip of the writer." );
+	copyToOutput->setDefault( false );
+
 	OFX::PushButtonParamDescriptor* render = desc.definePushButtonParam( kParamWriterRender );
 	render->setLabels( "Render", "Render", "Render step" );
 	render->setHint("Force render (writing)");
@@ -60,7 +65,6 @@ void describeWriterParamsInContext( OFX::ImageEffectDescriptor& desc,
 	OFX::BooleanParamDescriptor* renderAlways = desc.defineBooleanParam( kParamWriterRenderAlways );
 	renderAlways->setLabel( "Render always" );
 	renderAlways->setHint( "This is only useful as a workaround for GUI applications." );
-//	renderAlways->setDefault( false );
 	renderAlways->setDefault( true ); // because tuttle is not declared as a background renderer
 
 	OFX::IntParamDescriptor* forceNewRender = desc.defineIntParam( kParamWriterForceNewRender );


### PR DESCRIPTION
* This is only useful if you connect nodes to the output clip of the
writer.
* False by default.