### PR TITLE
CMake: use TUTTLE_EXPERIMENTAL to build plugins with major version 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project (TuttleOFX)
 # The install rule does not depend on all, i.e. everything will not be built before installing
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
 
+# Add a variable for experimental host/plugins features
+if(NOT TUTTLE_EXPERIMENTAL)
+  set(TUTTLE_EXPERIMENTAL 0)
+endif()
+add_definitions(-DTUTTLE_EXPERIMENTAL=${TUTTLE_EXPERIMENTAL})
+
 # Create an alias for all OFX plugins.
 add_custom_target(ofxplugins)
 

--- a/cmake/TuttleMacros.cmake
+++ b/cmake/TuttleMacros.cmake
@@ -83,6 +83,14 @@ function(tuttle_ofx_plugin_target PLUGIN_NAME)
         
         endif()
 
+        # By default, do not build a plugin with major version 0
+        if(${plugin_VERSION_MAJOR} EQUAL "0")
+          message(WARNING, " ${PLUGIN_NAME} plugin is experimental")
+          if(NOT ${TUTTLE_EXPERIMENTAL})
+            message(WARNING, " It will not be built")
+            return()
+          endif()
+        endif()
 
         # OpenFX and Terry are used by default
         include(UseOfxpp)

--- a/libraries/tuttle/src/tuttle/common/utils/global.hpp
+++ b/libraries/tuttle/src/tuttle/common/utils/global.hpp
@@ -108,9 +108,6 @@
  // Init dst buffer with red to highlight uninitialized pixels
  #define TUTTLE_INIT_IMAGE_BUFFERS 1
 
- // Make available experimental host / plugins features
- #define TUTTLE_EXPERIMENTAL 1
-
  // TUTTLE_TLOG* defines are used by developers for temporary displays during development stages.
  #define TUTTLE_TLOG TUTTLE_LOG
  #define TUTTLE_TLOG_TRACE TUTTLE_LOG_TRACE
@@ -131,7 +128,6 @@
  #define TUTTLE_EXPORT_WITH_TIMER 0
  #define TUTTLE_PNG_EXPORT_BETWEEN_NODES 0
  #define TUTTLE_INIT_IMAGE_BUFFERS 0
- #define TUTTLE_EXPERIMENTAL 0
 
 // TUTTLE_TLOG* are removed in release mode.
  #define TUTTLE_TLOG TUTTLE_LOG_DEBUG


### PR DESCRIPTION
* By default, do not build a plugin with major version 0.
* TUTTLE_EXPERIMENTAL is not related to release/debug build anymore: it
must be specify by the developer when create the Makefile.