### PR TITLE
README: add Documentation section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,16 @@ add_subdirectory(applications)
 # Add a target to generate API documentation with Doxygen
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/code/Doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doc/code/Doxyfile @ONLY)
+  set(doxyfile_in ${PROJECT_SOURCE_DIR}/doc/code/Doxyfile)
+  set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+  configure_file(${doxyfile_in} ${doxyfile} @ONLY)
+
   FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/doc)
   add_custom_target(doc
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/code/Doxyfile
+    COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating TuttleHOST documentation with Doxygen" VERBATIM
     )
-  install(DIRECTORY "${CMAKE_BINARY_DIR}/share/doc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/doc" OPTIONAL)
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/share/doc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share" OPTIONAL)
 
 endif(DOXYGEN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,12 @@ add_subdirectory(applications)
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/code/Doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doc/code/Doxyfile @ONLY)
-  FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/tuttle/doc)
+  FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/share/doc)
   add_custom_target(doc
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/code/Doxyfile
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating TuttleHOST documentation with Doxygen" VERBATIM
     )
-  # install(DIRECTORY "${CMAKE_BINARY_DIR}/share/tuttle/doc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/tuttle/doc")
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/share/doc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/doc" OPTIONAL)
 
 endif(DOXYGEN_FOUND)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![TuttleOFX](https://github.com/tuttleofx/TuttleOFX/raw/master/plugins/_scripts/ImageEffectApi/Resources/L_ProjectName_.png "TuttleOFX")TuttleOFX
 ========================
 **Project under early development.**
-  
+
+[![Build Status](https://travis-ci.org/tuttleofx/TuttleOFX.svg?branch=develop)](https://travis-ci.org/tuttleofx/TuttleOFX)
+
 TuttleOFX project is an image processing framework based on [OpenFX plugin format](http://openfx.sourceforge.net/).  
 More informations on the official website :[http://www.tuttleofx.org](http://www.tuttleofx.org).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ See [**COPYING.md**](COPYING.md)
 
 Compilation
 -----------
-
 Getting the source
 >    `git clone --recursive git://github.com/tuttleofx/TuttleOFX.git`  
 
@@ -28,8 +27,12 @@ See [**INSTALL.md**](INSTALL.md)
 
 Plugin creation
 ---------------
-
 See [**plugins/_scripts/README.md**](plugins/_scripts/README.md)
+
+
+Documentation
+-----------
+See [**Doxygen documentation**](http://tuttleofx.github.io/TuttleOFX/).
 
 
 Tested compilers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![TuttleOFX](https://github.com/tuttleofx/TuttleOFX/raw/master/plugins/_scripts/ImageEffectApi/Resources/L_ProjectName_.png "TuttleOFX")TuttleOFX
 ========================
-**Project under early development.**
 
 [![Build Status](https://travis-ci.org/tuttleofx/TuttleOFX.svg?branch=develop)](https://travis-ci.org/tuttleofx/TuttleOFX)
 

--- a/doc/code/Doxyfile
+++ b/doc/code/Doxyfile
@@ -754,7 +754,6 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = . \
-                         @CMAKE_CURRENT_SOURCE_DIR@/applications \
                          @CMAKE_CURRENT_SOURCE_DIR@/libraries/tuttle
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/code/Doxyfile
+++ b/doc/code/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/share/doc
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/share
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -753,8 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = . \
-                         @CMAKE_CURRENT_SOURCE_DIR@/libraries/tuttle
+INPUT                  = @PROJECT_SOURCE_DIR@/libraries/tuttle
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/code/Doxyfile
+++ b/doc/code/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/share/tuttle/doc
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/share/doc
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/doc/code/Doxyfile
+++ b/doc/code/Doxyfile
@@ -755,8 +755,7 @@ WARN_LOGFILE           =
 
 INPUT                  = . \
                          @CMAKE_CURRENT_SOURCE_DIR@/applications \
-                         @CMAKE_CURRENT_SOURCE_DIR@/plugins \
-                         @CMAKE_CURRENT_SOURCE_DIR@/libraries
+                         @CMAKE_CURRENT_SOURCE_DIR@/libraries/tuttle
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/code/Doxyfile
+++ b/doc/code/Doxyfile
@@ -709,7 +709,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_UNDOCUMENTED   = YES
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters
@@ -1146,7 +1146,7 @@ HTML_EXTRA_FILES       =
 # Minimum value: 0, maximum value: 359, default value: 220.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_HUE    = 100
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
 # in the HTML output. For a value of 0 the output will use grayscales only. A
@@ -1173,7 +1173,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the

--- a/doc/code/SConscript
+++ b/doc/code/SConscript
@@ -1,6 +1,0 @@
-Import( 'project', 'libs' )
-
-codedoc = project.env.Doxygen( '#doc/code/Doxyfile' )
-Alias( ['doc', 'codedoc', 'doxygen'], codedoc )
-Clean( ['doc', 'codedoc', 'doxygen'], ['#dist/doc/code'] )
-


### PR DESCRIPTION
Doxygen documentation is store in the gh-pages of the project (see branch gh-pages):
http://tuttleofx.github.io/TuttleOFX/