### PR TITLE
host writers: fix update of filename OFX parameter

### DIFF
--- a/libraries/tuttle/src/tuttle/plugin/context/WriterPlugin.cpp
+++ b/libraries/tuttle/src/tuttle/plugin/context/WriterPlugin.cpp
@@ -32,6 +32,9 @@ WriterPlugin::WriterPlugin( OfxImageEffectHandle handle )
 	_paramPremult = fetchBooleanParam( kParamPremultiplied );
 	_paramExistingFile = fetchChoiceParam( kParamWriterExistingFile );
 	_paramForceNewRender = fetchIntParam( kParamWriterForceNewRender );
+
+	// update params
+	changedParam( OFX::InstanceChangedArgs(), kTuttlePluginFilename );
 }
 
 WriterPlugin::~WriterPlugin( )


### PR DESCRIPTION
If you load a nuke project file for example.