### PR TITLE
Simplify properties access in python binding

### DIFF
--- a/libraries/tuttle/src/tuttle/host/ofx/property/OfxhProperty.hpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/property/OfxhProperty.hpp
@@ -173,6 +173,12 @@ public:
 	{
 		return _type;
 	}
+
+	/// get the type of this property as a string
+	std::string getTypeStr() const
+	{
+		return mapTypeEnumToString(_type);
+	}
 #ifndef SWIG
 	/// add a notify hook
 	void addNotifyHook( OfxhNotifyHook* hook )

--- a/libraries/tuttle/src/tuttle/host/ofx/property/OfxhPropertyTemplate.hpp
+++ b/libraries/tuttle/src/tuttle/host/ofx/property/OfxhPropertyTemplate.hpp
@@ -31,6 +31,8 @@
 
 #include "OfxhProperty.hpp"
 
+#include <boost/type_traits/is_pointer.hpp>
+
 namespace tuttle {
 namespace host {
 namespace ofx {
@@ -215,6 +217,8 @@ public:
 	/// return the value as a string
 	inline std::string getStringValueAt( int index = 0 ) const
 	{
+		if( boost::is_pointer<Type>::value)
+			return "";
 		return boost::lexical_cast<std::string>( _value[index] );
 	}
 

--- a/libraries/tuttle/src/tuttle/host/ofx/property/OfxhSet.i
+++ b/libraries/tuttle/src/tuttle/host/ofx/property/OfxhSet.i
@@ -10,6 +10,9 @@
 #include <tuttle/host/ofx/property/OfxhSet.hpp>
 %}
 
+namespace std {
+%template(VectorVoidPtr) vector<void*>;
+}
 
 %factory(tuttle::host::ofx::property::OfxhProperty& fetchProperty,
     tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhIntValue>,

--- a/libraries/tuttle/src/tuttle/host/ofx/property/OfxhSet.i
+++ b/libraries/tuttle/src/tuttle/host/ofx/property/OfxhSet.i
@@ -2,18 +2,45 @@
 %include <tuttle/host/ofx/property/OfxhProperty.i>
 %include <tuttle/host/ofx/property/OfxhPropertyTemplate.i>
 
+%include <factory.i>
+
+%include <std_vector.i>
+
 %{
 #include <tuttle/host/ofx/property/OfxhSet.hpp>
 %}
 
-%include <tuttle/host/ofx/property/OfxhSet.hpp>
 
+%factory(tuttle::host::ofx::property::OfxhProperty& fetchProperty,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhIntValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhDoubleValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhStringValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhPointerValue>)
+
+%factory(tuttle::host::ofx::property::OfxhProperty& fetchLocalProperty,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhIntValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhDoubleValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhStringValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhPointerValue>)
+
+%factory(tuttle::host::ofx::property::OfxhProperty& at,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhIntValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhDoubleValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhStringValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhPointerValue>)
+
+%factory(tuttle::host::ofx::property::OfxhProperty& localAt,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhIntValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhDoubleValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhStringValue>,
+    tuttle::host::ofx::property::OfxhPropertyTemplate<tuttle::host::ofx::property::OfxhPointerValue>)
+
+%include <tuttle/host/ofx/property/OfxhSet.hpp>
 
 namespace tuttle {
 namespace host {
 namespace ofx {
 namespace property {
-
 
 %extend OfxhSet
 {


### PR DESCRIPTION
Also use explicit ensurePreload function.
