### PR TITLE
tuttleHost: preload can be called several times

### DIFF
--- a/libraries/tuttle/src/tuttle/host/Core.cpp
+++ b/libraries/tuttle/src/tuttle/host/Core.cpp
@@ -65,9 +65,6 @@ Core::~Core()
 
 void Core::preload( const bool useCache )
 {
-	if( _isPreloaded )
-		return;
-	
 	_isPreloaded = true;
 	
 	//	typedef boost::archive::binary_oarchive OArchive;

--- a/libraries/tuttle/src/tuttle/host/Core.hpp
+++ b/libraries/tuttle/src/tuttle/host/Core.hpp
@@ -68,6 +68,15 @@ public:
 
 
 public:
+	/**
+	 * @brief Ensure preload has been done once.
+	 */
+	void ensurePreload( const bool useCache = true )
+	{
+		if( _isPreloaded )
+			return;
+		preload( useCache );
+	}
 	void preload( const bool useCache = true );
 
 	const ofx::OfxhPlugin& operator[]( const std::string& name ) const

--- a/libraries/tuttle/tests/ofx/clone/ofx_clone.cpp
+++ b/libraries/tuttle/tests/ofx/clone/ofx_clone.cpp
@@ -18,9 +18,6 @@ BOOST_AUTO_TEST_CASE( ofx_imageEffect_clones )
 	using namespace std;
 	using namespace tuttle::host;
 
-	core().getPluginCache().addDirectoryToPath( BOOST_PP_STRINGIZE(TUTTLE_PLUGIN_PATH) );
-	tuttle::host::core().preload();
-
 	// get some plugins examples
 	tuttle::host::ofx::imageEffect::OfxhImageEffectPlugin* plugin = tuttle::host::core().getImageEffectPluginById( "tuttle.pngreader" );
 	BOOST_CHECK( plugin != NULL );

--- a/libraries/tuttle/tests/ofx/plugin/ofx_plugin.cpp
+++ b/libraries/tuttle/tests/ofx/plugin/ofx_plugin.cpp
@@ -30,9 +30,6 @@ BOOST_AUTO_TEST_CASE( imageeffectplugin_serialization )
 	using namespace tuttle::host::ofx;
 	using namespace tuttle::host::ofx::imageEffect;
 
-	core().getPluginCache().addDirectoryToPath( BOOST_PP_STRINGIZE(TUTTLE_PLUGIN_PATH) );
-	core().preload();
-
 	OfxhImageEffectPlugin* plugin = core().getImageEffectPluginById( "tuttle.invert" );
 
 	//	typedef boost::archive::binary_oarchive OArchive;

--- a/libraries/tuttle/tests/time/time.cpp
+++ b/libraries/tuttle/tests/time/time.cpp
@@ -13,15 +13,6 @@ using namespace tuttle::host;
 
 BOOST_AUTO_TEST_SUITE( time_tests_suite01 )
 
-BOOST_AUTO_TEST_CASE( preload )
-{
-	TUTTLE_LOG_INFO( "-------- LOADING OPENFX PLUGINS --------" );
-	core().getPluginCache().addDirectoryToPath( BOOST_PP_STRINGIZE(TUTTLE_PLUGIN_PATH) );
-	core().preload();
-//	TUTTLE_TLOG( TUTTLE_TRACE, core().getImageEffectPluginCache() );
-	TUTTLE_LOG_INFO( "----------------- DONE -----------------" );
-}
-
 BOOST_AUTO_TEST_CASE( time_shift_offset_null )
 {
 	TUTTLE_LOG_INFO( "******** PROCESS TIMESHIFT ********" );


### PR DESCRIPTION
New method "ensurePreload" allows to ensure that the preload is done
once.