### PR TITLE
sam mv: fixed check of move of several sequences

### DIFF
--- a/applications/sam/sam_mv.py
+++ b/applications/sam/sam_mv.py
@@ -153,7 +153,7 @@ class Sam_mv(samUtils.Sam):
         if not len(inputItems):
             self.logger.error('No existing file corresponds to the given input sequence: ' + inputPath)
             exit(-1)
-        if len(inputItems) > 0:
+        if len(inputItems) > 1:
             self.logger.error('Several items ' + str([item.getFilename() for item in inputItems]) + ' correspond to the given input sequence: ' + inputPath)
             exit(-1)
 


### PR DESCRIPTION
Before a move, the command line checks if the given input sequence
corresponds to several sequences according to the sequence parser
browse. If so, we consider it as an error, and no move is done.