### PR TITLE
CMake: fixed find openjpeg v2.x

### DIFF
--- a/cmake/FindOpenJpeg.cmake
+++ b/cmake/FindOpenJpeg.cmake
@@ -37,7 +37,7 @@ find_path(OPENJPEG_INCLUDE_DIR
 
 # Looking for library path
 find_library(OPENJPEG_LIBRARY
-    NAMES         openjpeg
+    NAMES         openjpeg openjp2
     HINTS         ${_openjpeg_SEARCH_DIRS}
   PATH_SUFFIXES lib64 lib
 )


### PR DESCRIPTION
Since v2, the library has been renamed.