### PR TITLE
EXR reader: fix process of exr sequences with holes

### DIFF
--- a/plugins/image/io/Exr/src/reader/EXRReaderPlugin.cpp
+++ b/plugins/image/io/Exr/src/reader/EXRReaderPlugin.cpp
@@ -270,7 +270,10 @@ bool EXRReaderPlugin::getRegionOfDefinition(const OFX::RegionOfDefinitionArgumen
 {
     const std::string filepath(getAbsoluteFilenameAt(args.time));
     if(!bfs::exists(filepath))
-        return false;
+    {
+        BOOST_THROW_EXCEPTION(exception::FileInSequenceNotExist() << exception::user("EXR: Unable to open file")
+                                                                  << exception::filename(filepath));
+    }
 
     try
     {


### PR DESCRIPTION
* Fix #541 
* The "continueOnMissingFile" host feature was not working with EXR
sequences.
* This commit throws a specific exception when the host cannot
getRegionOfDefinition of the EXR reader plugin.