### PR TITLE
oiio pixel aspect ratio support #546

### DIFF
--- a/plugins/image/io/OpenImageIO/src/mainEntry.cpp
+++ b/plugins/image/io/OpenImageIO/src/mainEntry.cpp
@@ -1,5 +1,5 @@
 #define OFXPLUGIN_VERSION_MAJOR 1
-#define OFXPLUGIN_VERSION_MINOR 1
+#define OFXPLUGIN_VERSION_MINOR 2
 
 #include <tuttle/plugin/Plugin.hpp>
 #include "reader/OpenImageIOReaderPluginFactory.hpp"

--- a/plugins/image/io/OpenImageIO/src/reader/OpenImageIOReaderPlugin.cpp
+++ b/plugins/image/io/OpenImageIO/src/reader/OpenImageIOReaderPlugin.cpp
@@ -177,7 +177,8 @@ void OpenImageIOReaderPlugin::getClipPreferences(OFX::ClipPreferencesSetter& cli
         }
     }
 
-    clipPreferences.setPixelAspectRatio(*this->_clipDst, 1.0);
+    float par = spec.get_float_attribute("PixelAspectRatio", 1.0f);
+    clipPreferences.setPixelAspectRatio(*this->_clipDst, par);
     in->close();
 }
 

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
@@ -547,6 +547,9 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
     spec.attribute("CompressionQuality", params._quality);
     spec.attribute("Orientation", params._orientation);
 
+    const float par = _plugin._clipSrc->getPixelAspectRatio();
+    spec.attribute("PixelAspectRatio", par);
+
     if(!out->open(filepath, spec))
     {
         BOOST_THROW_EXCEPTION(exception::Unknown() << exception::user("OIIO Writer: " + out->geterror())


### PR DESCRIPTION
Warning: OpenColorIO support [jpeg pixel aspect ratio from 1.6.8 version](https://github.com/OpenImageIO/oiio/blob/master/CHANGES#L649).
