### PR TITLE
oiio writer: add sub sampling parameter

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,6 +80,11 @@ git clone https://github.com/tuttleofx/TuttleOFX-data.git
 Tests of host ( __libraries/tuttle/tests__ ) and plugins ( __tests__ directory in each plugin, with test files prefixed by "plugin_") with Boost Unit Test Framework.
 After compiling the project, executables are in __testBin__ directory.
 
+The tests of the IO plugins need images which can be found in the [TuttleOFX-data](https://github.com/tuttleofx/TuttleOFX-data) repository. To indicate the path to these images:
+```
+export TUTTLE_TEST_DATA=/path/to/TuttleOFX-data
+```
+
 - Python tests
 
 Test of host ( __libraries/tuttle/pyTest__ ) with nosetests tool.

--- a/plugins/image/io/OpenImageIO/src/mainEntry.cpp
+++ b/plugins/image/io/OpenImageIO/src/mainEntry.cpp
@@ -1,5 +1,5 @@
 #define OFXPLUGIN_VERSION_MAJOR 1
-#define OFXPLUGIN_VERSION_MINOR 3
+#define OFXPLUGIN_VERSION_MINOR 4
 
 #include <tuttle/plugin/Plugin.hpp>
 #include "reader/OpenImageIOReaderPluginFactory.hpp"

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterDefinitions.hpp
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterDefinitions.hpp
@@ -36,6 +36,27 @@ enum ETuttlePluginComponents
 static const std::string kParamOutputQuality = "quality";
 static const std::string kParamOutputQualityLabel = "Quality";
 
+enum ETuttlePluginSubsampling
+{
+    eETuttlePluginSubsampling420 = 0,
+    eETuttlePluginSubsampling422,
+    eETuttlePluginSubsampling411,
+    eETuttlePluginSubsampling444
+};
+
+static const std::string kParamOutputSubsampling = "subsampling";
+static const std::string kParamOutputSubsamplingLabel = "Subsampling";
+static const std::string kParamOutputSubsamplingHint = "Controlling chroma-subsampling of output JPEG files:\n"
+                                                 "4:2:0 : one chrominance component for every 2x2 block of pixels.\n"
+                                                 "4:2:2 : one chrominance component for every 2x1 block of pixels.\n"
+                                                 "4:1:1 : one chrominance component for every 4x1 block of pixels.\n"
+                                                 "4:4:4 : one chrominance component for every pixel (no subsampling)\n";
+
+static const std::string kParamOutputSubsampling420 = "420";
+static const std::string kParamOutputSubsampling422 = "422";
+static const std::string kParamOutputSubsampling411 = "411";
+static const std::string kParamOutputSubsampling444 = "444";
+
 static const std::string kParamOutputOrientation = "orientation";
 static const std::string kParamOutputOrientationLabel = "Orientation";
 

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPlugin.cpp
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPlugin.cpp
@@ -19,6 +19,7 @@ OpenImageIOWriterPlugin::OpenImageIOWriterPlugin(OfxImageEffectHandle handle)
     _components = fetchChoiceParam(kTuttlePluginChannel);
     _orientation = fetchChoiceParam(kParamOutputOrientation);
     _quality = fetchIntParam(kParamOutputQuality);
+    _paramSubsampling = fetchChoiceParam(kParamOutputSubsampling);
 }
 
 OpenImageIOWriterProcessParams OpenImageIOWriterPlugin::getProcessParams(const OfxTime time)
@@ -29,6 +30,7 @@ OpenImageIOWriterProcessParams OpenImageIOWriterPlugin::getProcessParams(const O
     params._filepath = getAbsoluteFilenameAt(time);
     params._components = static_cast<ETuttlePluginComponents>(this->_components->getValue());
     params._bitDepth = static_cast<ETuttlePluginBitDepth>(this->_paramBitDepth->getValue());
+    params._subsampling = static_cast<ETuttlePluginSubsampling>(_paramSubsampling->getValue());
     params._quality = _quality->getValue();
     params._orientation = static_cast<int>(_orientation->getValue());
     params._premultiply = this->_paramPremult->getValue();

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPlugin.hpp
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPlugin.hpp
@@ -21,6 +21,7 @@ struct OpenImageIOWriterProcessParams
     std::string _filepath;               ///< filepath
     ETuttlePluginComponents _components; ///< Force RGB
     ETuttlePluginBitDepth _bitDepth;     ///< Output bit depth (real bit depth, not the buffer passed to OpenImageIO)
+    ETuttlePluginSubsampling _subsampling; ///< Output subsampling
 
     bool _premultiply; ///< Output premultiply
     int _quality;      ///< Output quality
@@ -42,6 +43,7 @@ public:
 public:
     OFX::ChoiceParam* _components; ///< Choose components RGBA/RGB
     OFX::IntParam* _quality;
+    OFX::ChoiceParam* _paramSubsampling;
     OFX::ChoiceParam* _orientation;
 };
 }

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPluginFactory.cpp
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterPluginFactory.cpp
@@ -105,6 +105,15 @@ void OpenImageIOWriterPluginFactory::describeInContext(OFX::ImageEffectDescripto
     quality->setDisplayRange(0, 100);
     quality->setDefault(80);
 
+    OFX::ChoiceParamDescriptor* subsampling = desc.defineChoiceParam(kParamOutputSubsampling);
+    subsampling->setLabel(kParamOutputSubsamplingLabel);
+    subsampling->setHint(kParamOutputSubsamplingHint);
+    subsampling->appendOption(kParamOutputSubsampling420);
+    subsampling->appendOption(kParamOutputSubsampling422);
+    subsampling->appendOption(kParamOutputSubsampling411);
+    subsampling->appendOption(kParamOutputSubsampling444);
+    subsampling->setDefault(0);
+
     OFX::ChoiceParamDescriptor* orientation = desc.defineChoiceParam(kParamOutputOrientation);
     orientation->setLabel(kParamOutputOrientationLabel);
     orientation->appendOption(kParamOutputOrientationNormal);

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
@@ -547,6 +547,24 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
     spec.attribute("CompressionQuality", params._quality);
     spec.attribute("Orientation", params._orientation);
 
+    // controlling chroma-subsampling of jpeg
+    // Other formats don't have this attribute and ignore it.
+    switch(params._subsampling)
+    {
+	case eETuttlePluginSubsampling420:
+	    spec.attribute("jpeg:subsampling", "4:2:0");
+	    break;
+	case eETuttlePluginSubsampling422:
+	    spec.attribute("jpeg:subsampling", "4:2:2");
+	    break;
+	case eETuttlePluginSubsampling411:
+	    spec.attribute("jpeg:subsampling", "4:1:1");
+	    break;
+	case eETuttlePluginSubsampling444:
+	    spec.attribute("jpeg:subsampling", "4:4:4");
+	    break;
+    }
+
     // write par, xdensity and ydensity to the output
     // Some formats (ie. TIF, JPEG...) make the difference between those attributes.
     // Some others (ie. DPX...) don't have density attributes and ignore them.

--- a/plugins/image/io/OpenImageIO/tests/plugin_io_openImageIO.cpp
+++ b/plugins/image/io/OpenImageIO/tests/plugin_io_openImageIO.cpp
@@ -34,7 +34,7 @@ std::string pluginName = "tuttle.oiioreader";
 std::string filename = "jpeg/BLU.JPG";
 #include <tuttle/test/io/reader.hpp>
 BOOST_AUTO_TEST_SUITE_END()
-/*
+
 BOOST_AUTO_TEST_SUITE( plugin_OpenImageIO_j2k_reader )
 std::string pluginName = "tuttle.oiioreader";
 std::string filename = "j2k/Bretagne1.j2k";
@@ -46,7 +46,7 @@ std::string pluginName = "tuttle.oiioreader";
 std::string filename = "jp2/relax.jp2";
 #include <tuttle/test/io/reader.hpp>
 BOOST_AUTO_TEST_SUITE_END()
-*/
+
 
 BOOST_AUTO_TEST_SUITE(plugin_OpenImageIO_png_reader)
 std::string pluginName = "tuttle.oiioreader";
@@ -61,13 +61,12 @@ std::string filename = "tif/test-ramp.tif";
 BOOST_AUTO_TEST_SUITE_END()
 
 //// WRITER ////
-/*
+
 BOOST_AUTO_TEST_SUITE( plugin_OpenImageIO_dpx_writer )
 std::string pluginName = "tuttle.oiiowriter";
 std::string filename = "test-oiio.dpx";
 #include <tuttle/test/io/writer.hpp>
 BOOST_AUTO_TEST_SUITE_END()
-*/
 
 BOOST_AUTO_TEST_SUITE(plugin_OpenImageIO_exr_writer)
 std::string pluginName = "tuttle.oiiowriter";
@@ -81,7 +80,6 @@ std::string filename = "test-oiio.jpg";
 #include <tuttle/test/io/writer.hpp>
 BOOST_AUTO_TEST_SUITE_END()
 
-/*
 BOOST_AUTO_TEST_SUITE( plugin_OpenImageIO_j2k_writer )
 std::string pluginName = "tuttle.oiiowriter";
 std::string filename = "test-oiio.j2k";
@@ -93,7 +91,6 @@ std::string pluginName = "tuttle.oiiowriter";
 std::string filename = "test-oiio.jp2";
 #include <tuttle/test/io/writer.hpp>
 BOOST_AUTO_TEST_SUITE_END()
-*/
 
 BOOST_AUTO_TEST_SUITE(plugin_OpenImageIO_png_writer)
 std::string pluginName = "tuttle.oiiowriter";


### PR DESCRIPTION
TODO: 
- up version of the oiio plugin.
- remove Jpeg and TurboJpeg plugins? (since oiio correctly writes jpeg)
