### PR TITLE
exrwriter: fixed output images 32i

### DIFF
--- a/plugins/image/io/Exr/src/mainEntry.cpp
+++ b/plugins/image/io/Exr/src/mainEntry.cpp
@@ -1,5 +1,5 @@
 #define OFXPLUGIN_VERSION_MAJOR 3
-#define OFXPLUGIN_VERSION_MINOR 0
+#define OFXPLUGIN_VERSION_MINOR 1
 
 #include <tuttle/plugin/Plugin.hpp>
 #include "reader/EXRReaderPluginFactory.hpp"

--- a/plugins/image/io/Exr/src/writer/EXRWriterProcess.tcc
+++ b/plugins/image/io/Exr/src/writer/EXRWriterProcess.tcc
@@ -156,13 +156,13 @@ void EXRWriterProcess<View>::multiThreadProcessImages(const OfxRectI& procWindow
                         switch(_plugin._clipSrc->getPixelComponents())
                         {
                             case OFX::ePixelComponentAlpha:
-                                writeImage<gray32_pixel_t>(src, _params._filepath, Imf::HALF);
+                                writeImage<gray32_pixel_t>(src, _params._filepath, Imf::UINT);
                                 break;
                             case OFX::ePixelComponentRGB:
-                                writeImage<rgb32_pixel_t>(src, _params._filepath, Imf::HALF);
+                                writeImage<rgb32_pixel_t>(src, _params._filepath, Imf::UINT);
                                 break;
                             case OFX::ePixelComponentRGBA:
-                                writeImage<rgba32_pixel_t>(src, _params._filepath, Imf::HALF);
+                                writeImage<rgba32_pixel_t>(src, _params._filepath, Imf::UINT);
                                 break;
                             default:
                                 BOOST_THROW_EXCEPTION(exception::Unsupported()


### PR DESCRIPTION
When src clip sets its components to auto.
