### PR TITLE
oiiowriter: fix alpha premult when converting pixels

### DIFF
--- a/plugins/image/io/OpenImageIO/src/reader/OpenImageIOReaderProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/reader/OpenImageIOReaderProcess.tcc
@@ -167,7 +167,7 @@ View& OpenImageIOReaderProcess<View>::readImage(View& dst, boost::scoped_ptr<Ope
     const stride_t zstride = ystride * tmpView.height();
 
     img->read_image(TypeDesc::UNKNOWN,        // it's to not convert into OpenImageIO, convert with GIL
-                    &((*tmpView.begin())[0]), // get the adress of the first channel value from the first pixel
+                    &((*tmpView.begin())[0]), // get the address of the first channel value from the first pixel
                     xstride, ystride, zstride, &progressCallback, this);
 
     copy_and_convert_pixels(tmpView, dst);

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
@@ -616,7 +616,7 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
     typedef typename boost::gil::channel_type<WImage>::type channel_t;
 
     out->write_image(oiioBitDepth,
-                     &((*vw.begin())[0]), // get the adress of the first channel value from the first pixel
+                     &((*vw.begin())[0]), // get the address of the first channel value from the first pixel
                      xstride, ystride, zstride, &progressCallback, this);
 
     out->close();

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
@@ -3,6 +3,7 @@
 
 #include <terry/globals.hpp>
 #include <terry/openexr/half.hpp>
+#include <terry/color/components.hpp>
 
 #include <tuttle/plugin/exceptions.hpp>
 
@@ -483,6 +484,7 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
 {
     using namespace boost;
     using namespace OpenImageIO;
+    using namespace terry::color::components;
 
     boost::scoped_ptr<ImageOutput> out(ImageOutput::create(filepath));
     if(out.get() == NULL)
@@ -491,8 +493,10 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
     }
     WImage img(src.width(), src.height());
 
+    ConvertionParameters parameters;
+    parameters.premultiplied = params._premultiply;
     typename WImage::view_t vw(view(img));
-    copy_and_convert_pixels(src, vw);
+    convertComponentsView(src, vw, parameters);
 
     OpenImageIO::TypeDesc oiioBitDepth;
     size_t sizeOfChannel = 0;

--- a/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
+++ b/plugins/image/io/OpenImageIO/src/writer/OpenImageIOWriterProcess.tcc
@@ -561,7 +561,7 @@ void OpenImageIOWriterProcess<View>::writeImage(View& src, const std::string& fi
 	spec.attribute("Copyright", params._copyright);
 
     spec.attribute("oiio:BitsPerSample", bitsPerSample);
-    spec.attribute("oiio:UnassociatedAlpha", params._premultiply);
+    spec.attribute("oiio:UnassociatedAlpha", ! params._premultiply);
     spec.attribute("CompressionQuality", params._quality);
     spec.attribute("Orientation", params._orientation + 1);
 


### PR DESCRIPTION
This seems to fix the cases of a conversion with the same bitDepth.
In case of a conversion from 32f to 16i, we still have problems with the apha channel (the __premultiplied__ plugin argument has no effect).